### PR TITLE
set creationdate based on iptc records

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+dev
+---
+
+- #1 Set the CreationDate based on information given in IPTC records
+  `Date Created` and `Time Created` (requres py-dateutil for
+  parsing the timezone information)  [fRiSi]
+
 0.3.1 (2012-12-21)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ dev
 
 - #1 Set the CreationDate based on information given in IPTC records
   `Date Created` and `Time Created` (requres py-dateutil for
-  parsing the timezone information)  [fRiSi]
+  parsing the timezone information).
+  If IPTC `Date Created` is not set, fallback to Exif `DateTimeOriginal`
+  [fRiSi]
 
 0.3.1 (2012-12-21)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name='unweb.iptc',
           'Products.CMFPlone',
           'Products.ATContentTypes',
           'IPTCInfo',
+          'py-dateutil',
       ],
       extras_require={
           'test': ['plone.app.testing',

--- a/unweb/iptc/browser.txt
+++ b/unweb/iptc/browser.txt
@@ -65,6 +65,11 @@ Check if all the keywords are there
     >>> [i in browser.contents for i in iptc_data[25]]
     [True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True]
 
+Check if the creation date has been set correctly
+
+    >>> portal['sample.jpg'].created()
+    DateTime('2009/08/20 11:27:38 GMT+2')
+
 Update the image metadata
 
     >>> browser.getLink('Edit').click()

--- a/unweb/iptc/subscribers.py
+++ b/unweb/iptc/subscribers.py
@@ -2,7 +2,6 @@ from Products.ATContentTypes.interface import IATImage
 from Products.Archetypes.interfaces import IObjectEditedEvent
 from Products.Archetypes.interfaces import IObjectInitializedEvent
 from Products.CMFCore.utils import getToolByName
-from datetime import datetime
 from dateutil import parser
 from iptcinfo import IPTCInfo
 from logging import getLogger
@@ -95,11 +94,8 @@ def readIPTC(obj, event):
             # unfortunately does not work on many systems
             # see http://stackoverflow.com/a/8525115/810427
             created = parser.parse(creation_timestamp)
-
-        elif creation_date is not None:
-            created = datetime.strptime(creation_date, '%Y%m%d')
         else:
-            # no iptc creation date info can be found, use exif creation date
+            # no iptc creation date+time can be found, use exif creation date
             created = obj.getEXIFOrigDate()
 
         obj.setCreationDate(created)


### PR DESCRIPTION
this branch implements a fix for #1 

unfortunately paring the timezone with `%z` does not work (at leas on my system):
datetime.strptime('20090820 112738+0200', '%Y%m%d %H%M%S%z'
so i introduced a new dependency `py-dateutil` instead of parsing timezone info manually

also amended the testcase.

on my machine, the test writing the information back to the image fails. (creation date is not written back since it can't be modified in plone-ui anyway)
somehow IPTCInfo adds a new record `{ 221: '0:0:0:-00001'}` when reading from the sample file.

@d-mo please review

please wait a few days before merging, deleting the branch and doing a new release, as i'll test this in production to be sure it's working out well. 
i can also do the pypi work if you grant me permission: pypi username: frisi
